### PR TITLE
Download checks

### DIFF
--- a/flash-it.sh
+++ b/flash-it.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-cd $(dirname $0) # Change directory to the scripts directory to make sure that all filepaths are correct and all downloads end up in the scripts directory
-
 VERSION="0.2.0"
 BRANCH=master
 UBOOT_JOB=u-boot

--- a/flash-it.sh
+++ b/flash-it.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd $(dirname $0) # Change directory to the scripts directory to make sure that all filepaths are correct and all downloads end up in the scripts directory
+
 VERSION="0.2.0"
 BRANCH=master
 UBOOT_JOB=u-boot
@@ -113,18 +115,22 @@ select OPTION in "PinePhone device" "PineTab device" "Dont Be Evil devkit"; do
 done
 
 # Downloading images
-echo -e "\e[1mDownloading images...\e[0m"
-WGET=$(wget_cmd)
-UBOOT_DOWNLOAD="https://gitlab.com/sailfishos-porters-ci/dont_be_evil-ci/-/jobs/artifacts/$BRANCH/download?job=$UBOOT_JOB"
-$WGET "${UBOOT_JOB}.zip" "${UBOOT_DOWNLOAD}" || {
-	echo >&2 "UBoot image download failed. Aborting."
-	exit 2
+ls "${UBOOT_JOB}.zip" || {
+	echo -e "\e[1mDownloading images...\e[0m"
+	WGET=$(wget_cmd)
+	UBOOT_DOWNLOAD="https://gitlab.com/sailfishos-porters-ci/dont_be_evil-ci/-/jobs/artifacts/$BRANCH/download?job=$UBOOT_JOB"
+	$WGET "${UBOOT_JOB}.zip" "${UBOOT_DOWNLOAD}" || {
+		echo >&2 "UBoot image download failed. Aborting."
+		exit 2
+	}
 }
 
-ROOTFS_DOWNLOAD="https://gitlab.com/sailfishos-porters-ci/dont_be_evil-ci/-/jobs/artifacts/$BRANCH/download?job=$ROOTFS_JOB"
-$WGET "${ROOTFS_JOB}.zip" "${ROOTFS_DOWNLOAD}" || {
-	echo >&2 "Root filesystem image download failed. Aborting."
-	exit 2
+ls "${ROOTFS_JOB}.zip" || {
+	ROOTFS_DOWNLOAD="https://gitlab.com/sailfishos-porters-ci/dont_be_evil-ci/-/jobs/artifacts/$BRANCH/download?job=$ROOTFS_JOB"
+	$WGET "${ROOTFS_JOB}.zip" "${ROOTFS_DOWNLOAD}" || {
+		echo >&2 "Root filesystem image download failed. Aborting."
+		exit 2
+	}
 }
 
 # Select flash target


### PR DESCRIPTION
# Download checks

The script now checks for the targeted file in the current directory before downloading it. This is to prevent re-downloading the same files if the script was aborted. It does this by checking if the targeted download file is already present in the directory before downloading.

```bash
ls "${UBOOT_JOB}.zip" || {
    # Downloads ${UBOOT_JOB}.zip
}
```

```bash
ls "${ROOTFS_JOB}.zip" || {
    # Download ${ROOTF_JOB}.zip
}