### PR TITLE
towboot flag and other fixes

### DIFF
--- a/flash-it.sh
+++ b/flash-it.sh
@@ -58,7 +58,7 @@ case $key in
                "				and u-boot-sunxi-with-spl.bin into dir and system will "\
                "				installed from it" \
                "	-b, --branch BRANCH	Download images from a specific Git branch." \
-               "	-t, --towboot		Do not install the u-boot bootloader (mbr) on sdcard,"\
+               "	-t, --towboot		Do not install the u-boot bootloader (mbr) on sdcard," \
 	       "				I have towboot installed on emmc and boot with vol+dn from sd."\
                "	-h, --help		Print this help and exit." \
                "" \


### PR DESCRIPTION
towboot flag added
fixed sdcard.img size to 8GB

still no optimized partion layout (not 2048 aligned)
home partition not resized on first start

towboot flag tested with sdcard.img only. After dd'ing to a real sdcard I could boot sfos with vol-dn at boot. Without vol-dn the device booted to the mobian on the emmc. It worked as it should.